### PR TITLE
Evitar refrescar el arbol

### DIFF
--- a/layers-editor/src/layers-api.js
+++ b/layers-editor/src/layers-api.js
@@ -30,7 +30,7 @@ define([ 'jquery', 'message-bus' ], function($, bus) {
 	function decorateCommons(o) {
 		o.merge = function(data) {
 			$.extend(o, data);
-			bus.send('layers-set-root', layerRoot);
+			//bus.send('layers-set-root', layerRoot);
 		};
 	}
 


### PR DESCRIPTION
El problema es que todas las capas están visibles al refrescar, por eso las 3000 peticiones. Sería mejor encontrar por qué el atributo 'visible' está siempre en 'true'.