### PR TITLE
Feature/tg 12 unify legends

### DIFF
--- a/base/src/legend-panel.js
+++ b/base/src/legend-panel.js
@@ -18,10 +18,6 @@ define([ 'jquery', 'i18n', 'customization', 'message-bus', 'layout', 'ui/ui' ], 
 
 	var layerRoot;
 
-	bus.listen('layers-loaded', function(e, newLayersRoot) {
-		layerRoot = JSON.parse(JSON.stringify(newLayersRoot));
-	});
-
 	//create dialog panel legend
 	ui.create('dialog', {
 		id: dialogId,
@@ -36,13 +32,14 @@ define([ 'jquery', 'i18n', 'customization', 'message-bus', 'layout', 'ui/ui' ], 
 		parent: dialogId
 	});
 
+	// returns how many layers of the given legendGroup are active
 	var getLegendGroupActive = function(legendGroup) {
 		var count = 0;
-		for (let n in layerRoot.portalLayers) {
-			var layer = layerRoot.portalLayers[n];
-			//TODO: get the wmsLayer, not the portalLayer (to check legendGroup)
+		for (let n in legendArrayInfo) {
+			var layer = legendArrayInfo[n][0];
+			//is there a layer of the same legend group remaining?
 			if(layer.legendGroup && layer.legendGroup == legendGroup) {
-				if(layer.active) count ++;
+				if(layer.visibility) count++;
 			}
 		}
 		return count;
@@ -63,7 +60,7 @@ define([ 'jquery', 'i18n', 'customization', 'message-bus', 'layout', 'ui/ui' ], 
 			let position = legendLastPriority;
 
 			if(legendInfo.legendGroup) {
-				if(getLegendGroupActive(legendInfo.legendGroup) > 0) {
+				if(getLegendGroupActive(legendInfo.legendGroup) > 1) {
 					//do nothing, group is already active
 					continue;
 				} else {
@@ -74,7 +71,7 @@ define([ 'jquery', 'i18n', 'customization', 'message-bus', 'layout', 'ui/ui' ], 
 
 			if (!legendInfo.visibility) {
 				if(legendInfo.legendGroup) {
-					if(getLegendGroupActive(legendInfo.legendGroup) > 1) {
+					if(getLegendGroupActive(legendInfo.legendGroup) > 0) {
 						//don't remove the layer, there are others of the same group
 						continue;
 					} else {

--- a/base/src/legend-panel.js
+++ b/base/src/legend-panel.js
@@ -36,10 +36,10 @@ define([ 'jquery', 'i18n', 'customization', 'message-bus', 'layout', 'ui/ui' ], 
 	var getLegendGroupActive = function(legendGroup) {
 		var count = 0;
 		for (let n in legendArrayInfo) {
-			var layer = legendArrayInfo[n][0];
-			//is there a layer of the same legend group remaining?
-			if(layer.legendGroup && layer.legendGroup == legendGroup) {
-				if(layer.visibility) count++;
+			var layer = legendArrayInfo[n];
+			//how many layers of the same legend group are visible?
+			if(layer[0] && layer[0].legendGroup && (layer[0].legendGroup == legendGroup)) {
+				if(layer[0].visibility) count++;
 			}
 		}
 		return count;

--- a/layers-editor/src/layers-schema.json
+++ b/layers-editor/src/layers-schema.json
@@ -272,6 +272,10 @@
           "title":"Info Link",
           "type":"string",
           "format":"uri"
+        },
+        "sameLegend":{
+          "title":"Same legend",
+          "type":"boolean"
         }
       },
       "required":[


### PR DESCRIPTION
Se pueden unificar leyendas desde la edición de capas: se puede hacer que un grupo tenga la misma leyenda para todas las capas activando un checkbox SameLegend a nivel de grupo.

Las leyendas con el mismo grupo de leyendas se mostrarán una sola vez, y no desaparecerán mientras quede activa una capa del grupo.

⚠️ HAY UN PR ASOCIADO EN APP-SNMB ⚠️ https://github.com/SNMBArgentina/app-snmb/pull/13 (capas Bosque Nativo y Pérdida de Tierras Forestales)